### PR TITLE
ts-vue-pluginに変更

### DIFF
--- a/src/javascript/package.json
+++ b/src/javascript/package.json
@@ -45,9 +45,9 @@
     "node-sass": "^4.11.0",
     "sass-loader": "^7.0.1",
     "ts-jest": "^23.0.0",
+    "ts-vue-plugin": "^0.2.0",
     "typescript": "~3.2.2",
     "vue-cli-plugin-vuetify": "^0.2.0",
-    "vue-template-compiler": "^2.5.17",
-    "vue-ts-plugin": "^0.1.0"
+    "vue-template-compiler": "^2.5.17"
   }
 }

--- a/src/javascript/tsconfig.json
+++ b/src/javascript/tsconfig.json
@@ -16,7 +16,7 @@
       "@/*": ["src/*"]
     },
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
-    "plugins": [{ "name": "vue-ts-plugin" }]
+    "plugins": [{ "name": "ts-vue-plugin" }]
   },
   "files": ["./src/shims-tsx.d.ts", "./src/shims-vue.d.ts"],
   "include": [

--- a/src/javascript/yarn.lock
+++ b/src/javascript/yarn.lock
@@ -9714,6 +9714,11 @@ ts-loader@^5.3.3:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
+ts-vue-plugin@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ts-vue-plugin/-/ts-vue-plugin-0.2.0.tgz#01e2a8e93b31db3ca8933917d352b5b5d93f410b"
+  integrity sha512-keTN89rBb0kIxhqO9o7QLuBg0k2wAM0aLNZhKE6+UTGS6+oCTTxWMSOFYlgXg2rrYEJcFBcQ7N3KIstJ8uGIew==
+
 tsconfig@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-7.0.0.tgz#84538875a4dc216e5c4a5432b3a4dec3d54e91b7"
@@ -10106,14 +10111,6 @@ vue-style-loader@^4.1.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.2.1:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.6.tgz#a807acbf3d51971d3721d75ecb1b927b517c1a02"
-  integrity sha512-OakxDGyrmMQViCjkakQFbDZlG0NibiOzpLauOfyCUVRQc9yPmTqpiz9nF0VeA+dFkXegetw0E5x65BFhhLXO0A==
-  dependencies:
-    de-indent "^1.0.2"
-    he "^1.1.0"
-
 vue-template-compiler@^2.5.17:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.5.tgz#2e3b4f20cdfa2a54a48895d97a5b711d0e7ad81c"
@@ -10126,13 +10123,6 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.8.2.tgz#dd73e80ba58bb65dd7a8aa2aeef6089cf6116f2a"
   integrity sha512-cliV19VHLJqFUYbz/XeWXe5CO6guzwd0yrrqqp0bmjlMP3ZZULY7fu8RTC4+3lmHwo6ESVDHFDsvjB15hcR5IA==
-
-vue-ts-plugin@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/vue-ts-plugin/-/vue-ts-plugin-0.1.0.tgz#d12e956010fc2b60ddf4b440ecd80ef8c0048716"
-  integrity sha1-0S6VYBD8K2Dd9LRA7NgO+MAEhxY=
-  dependencies:
-    vue-template-compiler "^2.2.1"
 
 vue@^2.5.17:
   version "2.6.5"


### PR DESCRIPTION
- vue-ts-pluginだと、vimでtsuquyomi-vueを使ったときにlintエラーが大量に出るので、ts-vue-pluginを使うようにしました。